### PR TITLE
Make grafana access

### DIFF
--- a/deploy-monitoring.sh
+++ b/deploy-monitoring.sh
@@ -7,7 +7,7 @@ ENV="prod"
 usage() {
   echo "Usage: $0 [--env local|prod]"
   echo "  --env local  Deploy to minikube; access Grafana via port-forward (default: prod)"
-  echo "  --env prod   Deploy to k3s with TLS ingress at https://grafana.hejnaluk.dev"
+  echo "  --env prod   Deploy to k3s with TLS ingress at https://hejnaluk.dev/grafana"
   exit 1
 }
 
@@ -38,7 +38,9 @@ echo "==> Installing kube-prometheus-stack..."
 helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
   --namespace monitoring \
   --create-namespace \
-  --set grafana.adminPassword=admin
+  --set grafana.adminPassword=admin \
+  --set "grafana.grafana\.ini.server.root_url=https://hejnaluk.dev/grafana" \
+  --set "grafana.grafana\.ini.server.serve_from_sub_path=true"
 
 echo "==> Applying ServiceMonitor..."
 kubectl apply -f "$K8S_DIR/base/servicemonitor.yaml"
@@ -57,7 +59,7 @@ echo ""
 echo "==> Done. Access the UIs with:"
 echo "    Prometheus: kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090"
 if [[ "$ENV" == "prod" ]]; then
-  echo "    Grafana:    https://grafana.hejnaluk.dev"
+  echo "    Grafana:    https://hejnaluk.dev/grafana"
 else
   echo "    Grafana:    ./port-forward-grafana.sh  (then open http://localhost:3000)"
 fi

--- a/k8s/monitoring/grafana-ingress.yaml
+++ b/k8s/monitoring/grafana-ingress.yaml
@@ -10,13 +10,13 @@ metadata:
 spec:
   tls:
     - hosts:
-        - grafana.hejnaluk.dev
-      secretName: grafana-tls
+        - hejnaluk.dev
+      secretName: hejnaluk-dev-tls
   rules:
-    - host: grafana.hejnaluk.dev
+    - host: hejnaluk.dev
       http:
         paths:
-          - path: /
+          - path: /grafana
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## Summary by Sourcery

Configure Grafana to be served from a TLS-enabled subpath on the main domain in the production monitoring deployment.

New Features:
- Expose Grafana in production via a new HTTPS ingress at https://hejnaluk.dev/grafana.

Enhancements:
- Configure Grafana to use a subpath root URL so it can be correctly served from /grafana behind the ingress.
- Update deployment script messaging to reflect the new Grafana access URL for the production environment.