### PR TITLE
Allow manual dispatch for production deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,7 +13,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' &&
+          startsWith(github.ref, 'refs/tags/v')) ||
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success')
+      }}
 
     steps:
       - name: Checkout repository
@@ -29,5 +35,15 @@ jobs:
             cd ~/metro-timetable
             git fetch --tags
             kubectl apply -k k8s/overlays/prod
+            kubectl rollout status deployment/metro-timetable -n metro-prod --timeout=120s
+
+      - name: Force restart deployment (manual runs only)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
             kubectl rollout restart deployment/metro-timetable -n metro-prod
             kubectl rollout status deployment/metro-timetable -n metro-prod --timeout=120s


### PR DESCRIPTION
Updated deployment conditions to allow manual triggers and successful workflow runs.

## Summary by Sourcery

Allow production deployment workflow to be triggered manually and ensure deployments restart the application after applying manifests.

Deployment:
- Enable manual (workflow_dispatch) triggering of the production deployment workflow in addition to workflow_run triggers.
- Restart the production metro-timetable deployment after applying Kubernetes manifests to ensure new changes are picked up.