### PR TITLE
Add scripts for local development and Grafana port forwarding

### DIFF
--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV="dev"
+K8S_DIR="$(dirname "$0")/k8s"
+
+usage() {
+  echo "Usage: $0 [--env dev|test|prod]"
+  echo "  --env dev   Build locally and deploy to metro-dev namespace (default)"
+  echo "  --env test  Pull ghcr.io/kejhy93/metro-timetable:main and deploy to metro-test namespace"
+  echo "  --env prod  Pull ghcr.io/kejhy93/metro-timetable:latest and deploy to metro-prod namespace"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+case "$ENV" in
+  dev)
+    LOCAL_IMAGE="localhost/metro-timetable:local"
+    echo "==> Building JAR..."
+    mvn -B clean package -DskipTests
+
+    echo "==> Building Docker image: $LOCAL_IMAGE..."
+    podman build -t "$LOCAL_IMAGE" .
+
+    echo "==> Loading image into minikube..."
+    podman save "$LOCAL_IMAGE" | minikube image load --overwrite=true -
+    ;;
+  test)
+    REMOTE_IMAGE="ghcr.io/kejhy93/metro-timetable:main"
+    echo "==> Loading remote image into minikube: $REMOTE_IMAGE..."
+    minikube image load "$REMOTE_IMAGE"
+    ;;
+  prod)
+    REMOTE_IMAGE="ghcr.io/kejhy93/metro-timetable:latest"
+    echo "==> Loading remote image into minikube: $REMOTE_IMAGE..."
+    minikube image load "$REMOTE_IMAGE"
+    ;;
+  *)
+    echo "Unknown environment: $ENV"
+    usage
+    ;;
+esac
+
+echo "==> Applying Kubernetes manifests for env=$ENV..."
+kubectl apply -k "$K8S_DIR/overlays/$ENV"
+
+echo "==> Waiting for rollout in namespace metro-$ENV..."
+kubectl rollout status deployment/metro-timetable -n "metro-$ENV" --timeout=120s
+
+if [[ "$ENV" == "dev" || "$ENV" == "test" || "$ENV" == "prod" ]]; then
+  if kill -0 "$(cat /tmp/minikube-tunnel.pid 2>/dev/null)" 2>/dev/null; then
+    echo "==> minikube tunnel already running (PID $(cat /tmp/minikube-tunnel.pid))"
+  else
+    echo "==> Starting minikube tunnel in background (PID will be saved to /tmp/minikube-tunnel.pid)..."
+    minikube tunnel > /tmp/minikube-tunnel.log 2>&1 &
+    echo $! > /tmp/minikube-tunnel.pid
+    echo "    Tunnel log: /tmp/minikube-tunnel.log"
+    echo "    To stop: kill \$(cat /tmp/minikube-tunnel.pid)"
+  fi
+fi
+
+echo ""
+echo "==> Done. Access the service with:"
+echo "    minikube service metro-timetable -n metro-$ENV --url"

--- a/port-forward-grafana.sh
+++ b/port-forward-grafana.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCAL_PORT="${1:-3001}"
+
+echo "==> Port-forwarding Grafana on http://localhost:${LOCAL_PORT}"
+echo "    Login: admin / admin"
+echo "    Press Ctrl+C to stop."
+echo ""
+
+kubectl port-forward -n monitoring svc/prometheus-grafana "${LOCAL_PORT}:80"


### PR DESCRIPTION
## Summary by Sourcery

Add helper scripts to simplify local Kubernetes deployments and Grafana access for development and testing.

New Features:
- Introduce deploy-local.sh script to build or load container images and deploy Kubernetes manifests to dev, test, or prod namespaces on minikube.
- Add port-forward-grafana.sh script to quickly port-forward the Grafana service to a local port for dashboard access.