### PR TITLE
Add Prometheus resource limits to optimize memory usage

### DIFF
--- a/k8s/monitoring/prometheus-values.yaml
+++ b/k8s/monitoring/prometheus-values.yaml
@@ -1,0 +1,10 @@
+grafana:
+  adminPassword: admin
+
+prometheus:
+  prometheusSpec:
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        memory: 256Mi


### PR DESCRIPTION
## Summary by Sourcery

Configure Prometheus and Grafana resource and access settings for the monitoring stack.

New Features:
- Introduce a Prometheus Helm values file defining memory resource requests and limits for the Prometheus server.
- Configure a default Grafana admin password in the monitoring values configuration.

Enhancements:
- Standardize Prometheus memory usage by setting explicit resource requests and limits in the monitoring configuration.