### PR TITLE
Set build root directory for Gradle actions in deployment configuration

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -70,6 +70,8 @@ jobs:
           distribution: 'temurin'
 
       - uses: gradle/actions/setup-gradle@v4
+        with:
+          build-root-directory: ui
 
       - name: Build wasmJs
         working-directory: ui
@@ -100,6 +102,8 @@ jobs:
           distribution: 'temurin'
 
       - uses: gradle/actions/setup-gradle@v4
+        with:
+          build-root-directory: ui
 
       - name: Build JVM uber JAR
         working-directory: ui


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Set the Gradle action build root directory to the ui subfolder in the production deployment workflow for both WebAssembly and JVM builds.