### PR TITLE
Update Android Gradle Plugin version to 8.13.2

### DIFF
--- a/ui/gradle/libs.versions.toml
+++ b/ui/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.2"
+agp = "8.13.2"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the Android Gradle Plugin (AGP) version in libs.versions.toml from 8.11.2 to 8.13.2.