### PR TITLE
Implement CORS configuration to allow specific origins

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=metro-timetable
 
 # CORS
-cors.allowed-origins=https://hejnaluk.github.io
+cors.allowed-origins=https://kejhy93.github.io
 cors.allowed-methods=GET,POST
 
 pid.client.path=https://data.pid.cz/PID_GTFS.zip


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust CORS allowed-origins setting to point to the new GitHub Pages domain.