### PR TITLE
Fix invalid timezone conversion

### DIFF
--- a/ui/composeApp/build.gradle.kts
+++ b/ui/composeApp/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
         }
         jsMain.dependencies {
             implementation(libs.ktor.client.js)
+            implementation(npm("@js-joda/timezone", "2.21.1"))
         }
         wasmJsMain.dependencies {
             implementation(libs.ktor.client.js)


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add @js-joda/timezone NPM package as a dependency for the jsMain source set.