### PR TITLE
Fix infinity cache on nginx

### DIFF
--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -19,7 +19,7 @@ server {
         alias /usr/share/nginx/html/;
 
         location ~* \.(wasm|js|css)$ {
-            add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
             try_files $uri =404;
         }
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -18,8 +18,13 @@ server {
     location /metro/ {
         alias /usr/share/nginx/html/;
 
-        location ~* \.(wasm|js|css)$ {
-            add_header Cache-Control "no-cache, no-store, must-revalidate";
+        location ~* /[0-9a-f]+\.wasm$ {
+            add_header Cache-Control "public, max-age=31536000, immutable";
+            try_files $uri =404;
+        }
+
+        location ~* \.(js|css|wasm)$ {
+            add_header Cache-Control "no-cache";
             try_files $uri =404;
         }
 


### PR DESCRIPTION
## Summary by Sourcery

Update nginx configuration to disable long-term caching for WebAssembly, JavaScript, and CSS assets.

Bug Fixes:
- Prevent clients from indefinitely caching outdated wasm, JS, and CSS assets by sending no-cache headers.

Enhancements:
- Align asset caching headers with no-cache policy for dynamic UI resources.