### PR TITLE
Add train detail screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This repository contains a Java-based application that provides metro timetable 
 - Fetches and parses Prague PID GTFS timetable data automatically.
 - Filters trips by active service IDs for today's date using `calendar.txt` (weekly schedule) and `calendar_dates.txt` (public holidays and exception overrides), so only trips scheduled to run today appear in results.
 - Queries upcoming train departures by station name with optional direction filtering.
+- Returns the full stop list for any specific trip, with arrival/departure times as ISO 8601 instants.
 - Caches parsed data in-memory; re-downloads only when the data is older than a configurable threshold.
+- Exposes UI refresh intervals via `GET /pid/config` so they can be tuned server-side without a client release.
 - Exposes Prometheus metrics for observability.
 - GTFS format: https://gtfs.org/documentation/schedule/reference/#stop_timestxt
 
@@ -72,11 +74,74 @@ curl -X POST http://localhost:8080/pid/station \
   {
     "routeId": "L991",
     "directionId": 0,
-    "departureTime": "14:32:00",
+    "departureTime": "2026-04-17T12:32:00Z",
     "destination": "Depo Hostivař",
-    "upcomingStations": ["Muzeum", "Náměstí Míru", "Jiřího z Poděbrad", "...]
+    "upcomingStations": ["Muzeum", "Náměstí Míru", "Jiřího z Poděbrad", "..."]
   }
 ]
+```
+
+### `GET /pid/trip`
+
+Returns all stops for a specific trip. Pass `departureTime` exactly as received in the `TrainDeparture.departureTime` field.
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `routeId` | string | yes | Route identifier (e.g. `"L991"`) |
+| `directionId` | integer | yes | Direction: `0` or `1` |
+| `departureTime` | string | yes | ISO 8601 instant from the `TrainDeparture.departureTime` field |
+
+**Example:**
+
+```bash
+curl "http://localhost:8080/pid/trip?routeId=L991&directionId=0&departureTime=2026-04-17T12:32:00Z"
+```
+
+**Response** — `TripDetail` object:
+
+```json
+{
+  "routeId": "L991",
+  "directionId": 0,
+  "destination": "Depo Hostivař",
+  "stops": [
+    { "stopName": "Zličín",          "arrivalTime": null,                  "departureTime": "2026-04-17T12:20:00Z" },
+    { "stopName": "Muzeum",          "arrivalTime": "2026-04-17T12:32:00Z","departureTime": "2026-04-17T12:32:00Z" },
+    { "stopName": "Depo Hostivař",   "arrivalTime": "2026-04-17T12:45:00Z","departureTime": null }
+  ]
+}
+```
+
+`arrivalTime` is `null` for the first stop; `departureTime` is `null` for the last stop.
+
+Returns `404` when the trip is no longer in cache (e.g. data refreshed between the departures fetch and the tap). Returns `400` when `departureTime` is not a valid ISO 8601 instant or a required parameter is missing.
+
+### `GET /pid/config`
+
+Returns the server-configured UI refresh intervals. Clients should re-fetch this periodically so interval changes take effect without a client release.
+
+**Example:**
+
+```bash
+curl http://localhost:8080/pid/config
+```
+
+**Response:**
+
+```json
+{
+  "departuresRefreshIntervalSeconds": 30,
+  "tripDetailRefreshIntervalSeconds": 10
+}
+```
+
+Configured via `application.properties`:
+
+```properties
+pid.refresh.departures.interval.seconds=30
+pid.refresh.trip-detail.interval.seconds=10
 ```
 
 ## Monitoring
@@ -138,12 +203,18 @@ ui/
     └── src/
         ├── commonMain/       # Shared Compose UI and business logic
         │   ├── data/
-        │   │   ├── api/      # Ktor HTTP client → POST /pid/station
+        │   │   ├── api/      # Ktor HTTP client (station, trip detail, config)
         │   │   ├── local/    # Hard-coded metro line/station data
+        │   │   ├── AppConfigStore.kt  # Polls GET /pid/config; StateFlow<AppConfig>
         │   │   └── MetroRepository.kt
         │   ├── di/           # Koin dependency injection module
         │   ├── navigation/   # Type-safe Compose Navigation
-        │   └── presentation/ # Screens: Line → Station → Direction → Departures
+        │   └── presentation/
+        │       ├── line/       # Line selection screen
+        │       ├── station/    # Station list screen
+        │       ├── direction/  # Direction selection screen
+        │       ├── departures/ # Upcoming departures (tappable cards)
+        │       └── detail/     # Train detail screen (all stops, highlights)
         ├── androidMain/      # Android entry point (MainActivity)
         ├── iosMain/          # iOS entry point (MainViewController)
         ├── jvmMain/          # Desktop entry point
@@ -153,12 +224,13 @@ ui/
 
 ### User flow
 
-**Line** → **Station** → **Direction** → **Departures**
+**Line** → **Station** → **Direction** → **Departures** → **Train Detail**
 
 1. Pick a metro line (A / B / C, colour-coded).
 2. Pick a station along that line.
 3. Pick a direction (terminus 0 or terminus 1).
-4. View upcoming train departures fetched from the backend.
+4. View upcoming train departures. Tap a card to open the train detail screen.
+5. See all stops for that trip with scheduled times and a relative countdown. Two distinct highlights show where the train currently is (filled `primaryContainer`) and where your station is (secondary-colour border). The list auto-scrolls to the train's current position on first load and refreshes every 10 seconds.
 
 ### Key dependencies
 
@@ -173,7 +245,9 @@ ui/
 
 ### Backend connection
 
-`MetroApiClient` calls `POST /pid/station`. In production the nginx container reverse-proxies `/pid/` to the backend `metro-timetable` service, so the frontend and API share the same origin (`https://hejnaluk.dev`). To point at a local backend, change `BASE_URL` in `ui/composeApp/src/commonMain/kotlin/.../data/api/MetroApiClient.kt`.
+`MetroApiClient` calls `POST /pid/station`, `GET /pid/trip`, and `GET /pid/config`. In production the nginx container reverse-proxies `/pid/` to the backend `metro-timetable` service, so the frontend and API share the same origin (`https://hejnaluk.dev`). To point at a local backend, change `BASE_URL` in `ui/composeApp/src/commonMain/kotlin/.../data/api/MetroApiClient.kt`.
+
+The app fetches `GET /pid/config` on startup and re-polls it every 60 seconds. If the endpoint is unreachable, hardcoded defaults (30 s / 10 s) are used and polling continues in the background.
 
 ### Build and run
 

--- a/server/.sdkmanrc
+++ b/server/.sdkmanrc
@@ -1,0 +1,1 @@
+java=25-amzn

--- a/server/src/main/java/org/hejnaluk/metrotimetable/controller/PIDController.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/controller/PIDController.java
@@ -3,19 +3,25 @@ package org.hejnaluk.metrotimetable.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hejnaluk.metrotimetable.dto.AppConfig;
 import org.hejnaluk.metrotimetable.dto.LineInfo;
 import org.hejnaluk.metrotimetable.dto.TrainDeparture;
+import org.hejnaluk.metrotimetable.dto.TripDetail;
 import org.hejnaluk.metrotimetable.service.ParseTimetableService;
 import org.hejnaluk.metrotimetable.service.TimetableRefreshService;
 import org.hejnaluk.metrotimetable.dto.StationRequest;
 import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @RestController
@@ -26,6 +32,12 @@ public class PIDController {
 
     private final TimetableRefreshService timetableRefreshService;
     private final ParseTimetableService parseTimetableService;
+
+    @Value("${pid.refresh.departures.interval.seconds:30}")
+    private long departuresRefreshIntervalSeconds;
+
+    @Value("${pid.refresh.trip-detail.interval.seconds:10}")
+    private long tripDetailRefreshIntervalSeconds;
 
     /**
      * Triggers a full timetable download-and-parse cycle.
@@ -64,6 +76,50 @@ public class PIDController {
     public ResponseEntity<List<LineInfo>> getLines() {
         log.info("GET /pid/lines - line list requested");
         return ResponseEntity.ok(parseTimetableService.getLines());
+    }
+
+    /**
+     * Returns all stops for a specific trip identified by route, direction, and departure time.
+     * <p>
+     * The {@code departureTime} must be an ISO 8601 instant whose Prague-local time matches
+     * the departure time of any stop in the target trip (e.g. the departure time shown in the
+     * departures list for the user's station).
+     *
+     * @param routeId       the route identifier (e.g. {@code "L991"})
+     * @param directionId   the direction (0 or 1)
+     * @param departureTime ISO 8601 instant identifying the trip
+     * @return {@code 200 OK} with the {@link TripDetail}, or {@code 404} if the trip is not found,
+     *         or {@code 400} if {@code departureTime} is not a valid ISO 8601 instant
+     */
+    @GetMapping("/trip")
+    public ResponseEntity<TripDetail> getTripDetail(
+            @RequestParam String routeId,
+            @RequestParam int directionId,
+            @RequestParam String departureTime) {
+        Instant parsedTime;
+        try {
+            parsedTime = Instant.parse(departureTime);
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest().build();
+        }
+        log.info("GET /pid/trip - routeId={}, directionId={}, departureTime={}", routeId, directionId, parsedTime);
+        return parseTimetableService.getTripDetail(routeId, directionId, parsedTime)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Returns the server-side refresh interval configuration for UI clients.
+     * <p>
+     * Clients should re-fetch this endpoint periodically so that interval changes
+     * take effect without requiring a client release.
+     *
+     * @return {@code 200 OK} with {@link AppConfig} containing the configured intervals
+     */
+    @GetMapping("/config")
+    public ResponseEntity<AppConfig> getConfig() {
+        log.info("GET /pid/config - config requested");
+        return ResponseEntity.ok(new AppConfig(departuresRefreshIntervalSeconds, tripDetailRefreshIntervalSeconds));
     }
 
 }

--- a/server/src/main/java/org/hejnaluk/metrotimetable/dto/AppConfig.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/dto/AppConfig.java
@@ -1,0 +1,7 @@
+package org.hejnaluk.metrotimetable.dto;
+
+public record AppConfig(
+        long departuresRefreshIntervalSeconds,
+        long tripDetailRefreshIntervalSeconds
+) {
+}

--- a/server/src/main/java/org/hejnaluk/metrotimetable/dto/TripDetail.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/dto/TripDetail.java
@@ -1,0 +1,11 @@
+package org.hejnaluk.metrotimetable.dto;
+
+import java.util.List;
+
+public record TripDetail(
+        String routeId,
+        int directionId,
+        String destination,
+        List<TripStop> stops
+) {
+}

--- a/server/src/main/java/org/hejnaluk/metrotimetable/dto/TripStop.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/dto/TripStop.java
@@ -1,0 +1,10 @@
+package org.hejnaluk.metrotimetable.dto;
+
+import java.time.Instant;
+
+public record TripStop(
+        String stopName,
+        Instant arrivalTime,
+        Instant departureTime
+) {
+}

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hejnaluk.metrotimetable.dto.LineInfo;
 import org.hejnaluk.metrotimetable.dto.TrainDeparture;
+import org.hejnaluk.metrotimetable.dto.TripDetail;
+import org.hejnaluk.metrotimetable.dto.TripStop;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -414,6 +416,49 @@ public class ParseTimetableService {
      */
     private static String getFormattedTime(LocalTime localTime) {
         return TIME_FORMATTER.format(localTime);
+    }
+
+    /**
+     * Returns full trip details for the given route, direction, and departure time.
+     * <p>
+     * Scans the cached trips for {@code routeId-directionId} and finds the first trip containing
+     * a stop whose {@code arrivalTime} or {@code departureTime} (as Prague local time) matches the
+     * provided {@link Instant}. This allows the client to pass the departure time at any stop in
+     * the trip — typically the departure time from the station shown in the departures list.
+     * <p>
+     * The first stop's {@code arrivalTime} is returned as {@code null} (terminus — no inbound service).
+     * The last stop's {@code departureTime} is returned as {@code null} (train terminates here).
+     *
+     * @param routeId       the route identifier (e.g. {@code "L991"})
+     * @param directionId   the direction (0 or 1)
+     * @param departureTime an {@link Instant} whose Prague-local time matches a stop in the target trip
+     * @return the {@link TripDetail} if a matching trip is found, or {@link Optional#empty()} if not
+     */
+    public Optional<TripDetail> getTripDetail(String routeId, int directionId, Instant departureTime) {
+        final TimetableData snapshot = timetableData;
+        final String key = routeId + "-" + directionId;
+        final ConcurrentSkipListMap<LocalTime, List<CompleteStop>> trips = snapshot.routeCache().get(key);
+        if (trips == null) return Optional.empty();
+
+        final LocalTime targetTime = departureTime.atZone(PRAGUE_ZONE).toLocalTime();
+        final LocalDate today = getToday();
+
+        return trips.values().stream()
+                .filter(stops -> stops.stream()
+                        .anyMatch(s -> s.departureTime().equals(targetTime) || s.arrivalTime().equals(targetTime)))
+                .findFirst()
+                .map(stops -> {
+                    final List<TripStop> tripStops = new ArrayList<>();
+                    for (int i = 0; i < stops.size(); i++) {
+                        final CompleteStop cs = stops.get(i);
+                        final Instant arrival = (i == 0) ? null
+                                : cs.arrivalTime().atDate(today).atZone(PRAGUE_ZONE).toInstant();
+                        final Instant departure = (i == stops.size() - 1) ? null
+                                : cs.departureTime().atDate(today).atZone(PRAGUE_ZONE).toInstant();
+                        tripStops.add(new TripStop(cs.stop().stopName(), arrival, departure));
+                    }
+                    return new TripDetail(routeId, directionId, stops.getLast().stop().stopName(), tripStops);
+                });
     }
 
     // --- Package-private test support ---

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -24,3 +24,7 @@ pid.client.station.max-limit=15
 # Cron for scheduled timetable refresh (default: daily at 04:00)
 pid.refresh.cron=0 0 4 * * *
 
+# UI refresh intervals (seconds) served via GET /pid/config
+pid.refresh.departures.interval.seconds=30
+pid.refresh.trip-detail.interval.seconds=10
+

--- a/server/src/test/java/org/hejnaluk/metrotimetable/controller/PIDControllerTest.java
+++ b/server/src/test/java/org/hejnaluk/metrotimetable/controller/PIDControllerTest.java
@@ -1,8 +1,11 @@
 package org.hejnaluk.metrotimetable.controller;
 
+import org.hejnaluk.metrotimetable.dto.AppConfig;
 import org.hejnaluk.metrotimetable.dto.LineInfo;
 import org.hejnaluk.metrotimetable.dto.StationRequest;
 import org.hejnaluk.metrotimetable.dto.TrainDeparture;
+import org.hejnaluk.metrotimetable.dto.TripDetail;
+import org.hejnaluk.metrotimetable.dto.TripStop;
 import org.hejnaluk.metrotimetable.service.ParseTimetableService;
 import org.hejnaluk.metrotimetable.service.TimetableRefreshService;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,12 +21,14 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class PIDControllerTest {
@@ -37,14 +42,23 @@ class PIDControllerTest {
     private MockMvc mockMvc;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         controller = new PIDController(timetableRefreshService, parseTimetableService);
+        // Inject @Value fields that Spring would normally populate
+        setField(controller, "departuresRefreshIntervalSeconds", 30L);
+        setField(controller, "tripDetailRefreshIntervalSeconds", 10L);
         LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
         validator.afterPropertiesSet();
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setValidator(validator)
                 .build();
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
     }
 
     @Test
@@ -192,5 +206,79 @@ class PIDControllerTest {
 
         mockMvc.perform(get("/pid/lines"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void getTripDetail_callsService() {
+        String routeId = "L991";
+        int directionId = 0;
+        Instant departureTime = Instant.parse("2026-03-30T12:00:00Z");
+        when(parseTimetableService.getTripDetail(routeId, directionId, departureTime)).thenReturn(Optional.empty());
+
+        controller.getTripDetail(routeId, directionId, departureTime.toString());
+
+        Mockito.verify(parseTimetableService, times(1)).getTripDetail(routeId, directionId, departureTime);
+    }
+
+    @Test
+    void getTripDetail_returnsServiceResult() {
+        String routeId = "L991";
+        int directionId = 0;
+        Instant departureTime = Instant.parse("2026-03-30T12:00:00Z");
+        TripDetail detail = new TripDetail(routeId, directionId, "Zličín", List.of(
+                new TripStop("Depo Hostivař", null, departureTime),
+                new TripStop("Zličín", departureTime, null)
+        ));
+        when(parseTimetableService.getTripDetail(routeId, directionId, departureTime)).thenReturn(Optional.of(detail));
+
+        var response = controller.getTripDetail(routeId, directionId, departureTime.toString());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(detail);
+    }
+
+    @Test
+    void getTripDetail_returns404_whenNotFound() throws Exception {
+        when(parseTimetableService.getTripDetail("L991", 0, Instant.parse("2026-03-30T12:00:00Z")))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/pid/trip")
+                        .param("routeId", "L991")
+                        .param("directionId", "0")
+                        .param("departureTime", "2026-03-30T12:00:00Z"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getTripDetail_rejects_missingRouteId() throws Exception {
+        mockMvc.perform(get("/pid/trip")
+                        .param("directionId", "0")
+                        .param("departureTime", "2026-03-30T12:00:00Z"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTripDetail_rejects_missingDepartureTime() throws Exception {
+        mockMvc.perform(get("/pid/trip")
+                        .param("routeId", "L991")
+                        .param("directionId", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTripDetail_rejects_invalidDepartureTimeFormat() throws Exception {
+        mockMvc.perform(get("/pid/trip")
+                        .param("routeId", "L991")
+                        .param("directionId", "0")
+                        .param("departureTime", "not-an-instant"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getConfig_returnsConfiguredValues() throws Exception {
+        mockMvc.perform(get("/pid/config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.departuresRefreshIntervalSeconds").value(30))
+                .andExpect(jsonPath("$.tripDetailRefreshIntervalSeconds").value(10));
     }
 }

--- a/server/src/test/java/org/hejnaluk/metrotimetable/service/ParseTimetableServiceTest.java
+++ b/server/src/test/java/org/hejnaluk/metrotimetable/service/ParseTimetableServiceTest.java
@@ -8,14 +8,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import org.hejnaluk.metrotimetable.dto.TripDetail;
+
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
 
@@ -339,6 +343,67 @@ class ParseTimetableServiceTest {
         List<ParseTimetableService.Trip> result = service.parseTrip(Set.of("L991"), Set.of("1111100-1"));
 
         assertThat(result).hasSize(2).allMatch(t -> t.routeId().equals("L991"));
+    }
+
+    // --- getTripDetail tests ---
+
+    @Test
+    void getTripDetail_returnsAllStopsForMatchingTrip() {
+        populateCache("L991-0", Map.of(
+                LocalTime.of(13, 0), stopsAt(LocalTime.of(13, 0), "Depo Hostivař", "Muzeum", "Zličín")
+        ));
+        // Muzeum is at index 1, departure time = 13:01
+        Instant departureInstant = LocalTime.of(13, 1).atDate(FIXED_TODAY).atZone(PRAGUE_ZONE).toInstant();
+
+        Optional<TripDetail> result = service.getTripDetail("L991", 0, departureInstant);
+
+        assertThat(result).isPresent();
+        TripDetail detail = result.get();
+        assertThat(detail.routeId()).isEqualTo("L991");
+        assertThat(detail.directionId()).isZero();
+        assertThat(detail.destination()).isEqualTo("Zličín");
+        assertThat(detail.stops()).hasSize(3);
+        assertThat(detail.stops().get(0).stopName()).isEqualTo("Depo Hostivař");
+        assertThat(detail.stops().get(1).stopName()).isEqualTo("Muzeum");
+        assertThat(detail.stops().get(2).stopName()).isEqualTo("Zličín");
+        // First stop has null arrivalTime (terminus — no inbound service)
+        assertThat(detail.stops().get(0).arrivalTime()).isNull();
+        // Last stop has null departureTime (train terminates here)
+        assertThat(detail.stops().get(2).departureTime()).isNull();
+        // Middle stop has both times set
+        assertThat(detail.stops().get(1).arrivalTime()).isNotNull();
+        assertThat(detail.stops().get(1).departureTime()).isNotNull();
+    }
+
+    @Test
+    void getTripDetail_returnsEmpty_whenTripNotFound() {
+        populateCache("L991-0", Map.of(
+                LocalTime.of(13, 0), stopsAt(LocalTime.of(13, 0), "Depo Hostivař", "Muzeum", "Zličín")
+        ));
+        Instant notFound = LocalTime.of(15, 0).atDate(FIXED_TODAY).atZone(PRAGUE_ZONE).toInstant();
+
+        Optional<TripDetail> result = service.getTripDetail("L991", 0, notFound);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getTripDetail_convertsLocalTimeToInstant_correctlyForPostMidnightTrip() {
+        // A post-midnight GTFS trip (e.g. originally "24:30:00") gets normalised to 00:30 via modulo.
+        // The server must convert it to an Instant using today's date (not yesterday's).
+        LocalTime postMidnight = LocalTime.of(0, 30);
+        populateCache("L991-0", Map.of(
+                postMidnight, stopsAt(postMidnight, "Depo Hostivař", "Muzeum")
+        ));
+        // Muzeum is at index 1, arrival = 00:31
+        Instant departureInstant = LocalTime.of(0, 30).atDate(FIXED_TODAY).atZone(PRAGUE_ZONE).toInstant();
+
+        Optional<TripDetail> result = service.getTripDetail("L991", 0, departureInstant);
+
+        assertThat(result).isPresent();
+        // Second stop's arrivalTime should be 00:31 on FIXED_TODAY
+        Instant expectedArrival = LocalTime.of(0, 31).atDate(FIXED_TODAY).atZone(PRAGUE_ZONE).toInstant();
+        assertThat(result.get().stops().get(1).arrivalTime()).isEqualTo(expectedArrival);
     }
 
     // --- helpers ---

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/App.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/App.kt
@@ -2,15 +2,22 @@ package org.hejnaluk.metrotimetable.ui
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import org.hejnaluk.metrotimetable.ui.data.AppConfigStore
 import org.hejnaluk.metrotimetable.ui.di.appModule
 import org.hejnaluk.metrotimetable.ui.navigation.AppNavigation
 import org.koin.compose.KoinApplication
+import org.koin.compose.koinInject
 
 @Composable
 fun App() {
     KoinApplication(application = {
         modules(appModule)
     }) {
+        val appConfigStore = koinInject<AppConfigStore>()
+        LaunchedEffect(Unit) {
+            appConfigStore.startPolling()
+        }
         MaterialTheme {
             AppNavigation()
         }

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/AppConfigStore.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/AppConfigStore.kt
@@ -1,0 +1,37 @@
+package org.hejnaluk.metrotimetable.ui.data
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.hejnaluk.metrotimetable.ui.data.api.AppConfig
+import org.hejnaluk.metrotimetable.ui.data.api.MetroApiClient
+
+private val DEFAULT_CONFIG = AppConfig(
+    departuresRefreshIntervalSeconds = 30L,
+    tripDetailRefreshIntervalSeconds = 10L
+)
+private const val CONFIG_FETCH_INTERVAL_MS = 60_000L
+
+class AppConfigStore(private val apiClient: MetroApiClient) {
+
+    private val _config = MutableStateFlow(DEFAULT_CONFIG)
+    val config: StateFlow<AppConfig> = _config.asStateFlow()
+
+    /**
+     * Fetches the config from the server and retries on a fixed interval.
+     * Call this from a [kotlinx.coroutines.CoroutineScope] tied to the app's lifetime
+     * (e.g. inside a [androidx.compose.runtime.LaunchedEffect] in the root composable).
+     * Falls back to defaults on any error and retries on the next cycle.
+     */
+    suspend fun startPolling() {
+        while (true) {
+            try {
+                _config.value = apiClient.fetchConfig()
+            } catch (_: Exception) {
+                // keep current value (default on first failure, last successful on later failures)
+            }
+            delay(CONFIG_FETCH_INTERVAL_MS)
+        }
+    }
+}

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/MetroRepository.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/MetroRepository.kt
@@ -2,6 +2,7 @@ package org.hejnaluk.metrotimetable.ui.data
 
 import org.hejnaluk.metrotimetable.ui.data.api.MetroApiClient
 import org.hejnaluk.metrotimetable.ui.data.api.TrainDeparture
+import org.hejnaluk.metrotimetable.ui.data.api.TripDetail
 import org.hejnaluk.metrotimetable.ui.data.local.LineDataSource
 import org.hejnaluk.metrotimetable.ui.data.local.MetroLine
 
@@ -45,4 +46,11 @@ class MetroRepository(
         routeId: String? = null
     ): Result<List<TrainDeparture>> =
         runCatching { apiClient.fetchDepartures(station, direction, limit, routeId) }
+
+    suspend fun fetchTripDetail(
+        routeId: String,
+        directionId: Int,
+        departureTime: String
+    ): Result<TripDetail> =
+        runCatching { apiClient.fetchTripDetail(routeId, directionId, departureTime) }
 }

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/AppConfig.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/AppConfig.kt
@@ -1,0 +1,9 @@
+package org.hejnaluk.metrotimetable.ui.data.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppConfig(
+    val departuresRefreshIntervalSeconds: Long,
+    val tripDetailRefreshIntervalSeconds: Long
+)

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/MetroApiClient.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/MetroApiClient.kt
@@ -9,6 +9,7 @@ import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -35,6 +36,20 @@ class MetroApiClient(engine: HttpClientEngine, private val baseUrl: String) {
 
     suspend fun fetchLines(): List<LineInfo> =
         client.get("$baseUrl/pid/lines").body()
+
+    suspend fun fetchTripDetail(
+        routeId: String,
+        directionId: Int,
+        departureTime: String
+    ): TripDetail =
+        client.get("$baseUrl/pid/trip") {
+            parameter("routeId", routeId)
+            parameter("directionId", directionId)
+            parameter("departureTime", departureTime)
+        }.body()
+
+    suspend fun fetchConfig(): AppConfig =
+        client.get("$baseUrl/pid/config").body()
 
     suspend fun fetchDepartures(
         station: String,

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/TripDetail.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/TripDetail.kt
@@ -1,0 +1,11 @@
+package org.hejnaluk.metrotimetable.ui.data.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TripDetail(
+    val routeId: String,
+    val directionId: Int,
+    val destination: String,
+    val stops: List<TripStop>
+)

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/TripStop.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/data/api/TripStop.kt
@@ -1,0 +1,10 @@
+package org.hejnaluk.metrotimetable.ui.data.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TripStop(
+    val stopName: String,
+    val arrivalTime: String?,   // ISO 8601 Instant, null for first stop (terminus — no inbound)
+    val departureTime: String?  // ISO 8601 Instant, null for last stop (train terminates here)
+)

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/di/AppModule.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/di/AppModule.kt
@@ -1,5 +1,6 @@
 package org.hejnaluk.metrotimetable.ui.di
 
+import org.hejnaluk.metrotimetable.ui.data.AppConfigStore
 import org.hejnaluk.metrotimetable.ui.data.MetroRepository
 import org.hejnaluk.metrotimetable.ui.data.api.MetroApiClient
 import org.hejnaluk.metrotimetable.ui.data.local.LineDataSource
@@ -7,6 +8,7 @@ import org.hejnaluk.metrotimetable.ui.data.local.LocalLineDataSource
 import org.hejnaluk.metrotimetable.ui.apiBaseUrl
 import org.hejnaluk.metrotimetable.ui.httpClientEngine
 import org.hejnaluk.metrotimetable.ui.presentation.departures.DeparturesViewModel
+import org.hejnaluk.metrotimetable.ui.presentation.detail.TrainDetailViewModel
 import org.hejnaluk.metrotimetable.ui.presentation.line.LinesViewModel
 import org.koin.compose.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -15,6 +17,8 @@ val appModule = module {
     single<LineDataSource> { LocalLineDataSource() }
     single { MetroApiClient(httpClientEngine(), apiBaseUrl()) }
     single { MetroRepository(get(), get()) }
-    viewModel { DeparturesViewModel(get()) }
+    single { AppConfigStore(get()) }
+    viewModel { DeparturesViewModel(get(), get()) }
+    viewModel { TrainDetailViewModel(get(), get()) }
     viewModel { LinesViewModel(get(), get()) }
 }

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/navigation/AppNavigation.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/navigation/AppNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.toRoute
 import androidx.compose.runtime.Composable
 import kotlinx.serialization.Serializable
 import org.hejnaluk.metrotimetable.ui.presentation.departures.DeparturesScreen
+import org.hejnaluk.metrotimetable.ui.presentation.detail.TrainDetailScreen
 import org.hejnaluk.metrotimetable.ui.presentation.direction.DirectionScreen
 import org.hejnaluk.metrotimetable.ui.presentation.line.LineScreen
 import org.hejnaluk.metrotimetable.ui.presentation.station.StationScreen
@@ -26,6 +27,14 @@ internal data class DeparturesRoute(
     val station: String,
     val directionId: Int,
     val destination: String
+)
+
+@Serializable
+internal data class TrainDetailRoute(
+    val routeId: String,
+    val directionId: Int,
+    val departureTime: String,
+    val station: String
 )
 
 @Composable
@@ -73,7 +82,27 @@ fun AppNavigation() {
                 destination = route.destination,
                 routeId = route.lineId,
                 onBack = { navController.popBackStack() },
-                onHome = { navController.popBackStack(LineRoute, inclusive = false) }
+                onHome = { navController.popBackStack(LineRoute, inclusive = false) },
+                onDepartureTapped = { departure ->
+                    navController.navigate(
+                        TrainDetailRoute(
+                            routeId = departure.routeId,
+                            directionId = departure.directionId,
+                            departureTime = departure.departureTime,
+                            station = route.station
+                        )
+                    )
+                }
+            )
+        }
+        composable<TrainDetailRoute> { backStackEntry ->
+            val route: TrainDetailRoute = backStackEntry.toRoute()
+            TrainDetailScreen(
+                routeId = route.routeId,
+                directionId = route.directionId,
+                departureTime = route.departureTime,
+                station = route.station,
+                onBack = { navController.popBackStack() }
             )
         }
     }

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/departures/DeparturesScreen.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/departures/DeparturesScreen.kt
@@ -45,6 +45,7 @@ fun DeparturesScreen(
     routeId: String? = null,
     onBack: () -> Unit,
     onHome: () -> Unit,
+    onDepartureTapped: (TrainDeparture) -> Unit = {},
     viewModel: DeparturesViewModel = koinViewModel()
 ) {
     LaunchedEffect(station, directionId, routeId) {
@@ -90,7 +91,8 @@ fun DeparturesScreen(
 
                 is DeparturesState.Success -> DeparturesList(
                     departures = s.departures,
-                    updatedAt = s.updatedAt
+                    updatedAt = s.updatedAt,
+                    onDepartureTapped = onDepartureTapped
                 )
             }
         }
@@ -98,7 +100,11 @@ fun DeparturesScreen(
 }
 
 @Composable
-private fun DeparturesList(departures: List<TrainDeparture>, updatedAt: LocalTime) {
+private fun DeparturesList(
+    departures: List<TrainDeparture>,
+    updatedAt: LocalTime,
+    onDepartureTapped: (TrainDeparture) -> Unit
+) {
     Column(modifier = Modifier.fillMaxSize()) {
         Text(
             text = "Updated: $updatedAt",
@@ -107,20 +113,21 @@ private fun DeparturesList(departures: List<TrainDeparture>, updatedAt: LocalTim
         )
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             items(departures) { departure ->
-                DepartureItem(departure = departure)
+                DepartureItem(departure = departure, onClick = { onDepartureTapped(departure) })
             }
         }
     }
 }
 
 @Composable
-private fun DepartureItem(departure: TrainDeparture) {
+private fun DepartureItem(departure: TrainDeparture, onClick: () -> Unit) {
     val departureInstant = Instant.parse(departure.departureTime)
     val minutesUntil = minutesUntil(departureInstant)
     val localTime = departureInstant
         .toLocalDateTime(TimeZone.currentSystemDefault()).time
 
     Card(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp)

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/departures/DeparturesViewModel.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/departures/DeparturesViewModel.kt
@@ -8,9 +8,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.hejnaluk.metrotimetable.ui.currentLocalTime
+import org.hejnaluk.metrotimetable.ui.data.AppConfigStore
 import org.hejnaluk.metrotimetable.ui.data.MetroRepository
 
-class DeparturesViewModel(private val repository: MetroRepository) : ViewModel() {
+class DeparturesViewModel(
+    private val repository: MetroRepository,
+    private val appConfigStore: AppConfigStore
+) : ViewModel() {
 
     private val _state = MutableStateFlow<DeparturesState>(DeparturesState.Loading)
     val state: StateFlow<DeparturesState> = _state.asStateFlow()
@@ -19,7 +23,7 @@ class DeparturesViewModel(private val repository: MetroRepository) : ViewModel()
         viewModelScope.launch {
             while (true) {
                 load(station, directionId, routeId)
-                delay(REFRESH_INTERVAL_MS)
+                delay(appConfigStore.config.value.departuresRefreshIntervalSeconds * 1_000L)
             }
         }
     }
@@ -36,9 +40,5 @@ class DeparturesViewModel(private val repository: MetroRepository) : ViewModel()
                 _state.value = DeparturesState.Error(error.message ?: "Unknown error")
             }
         )
-    }
-
-    companion object {
-        private const val REFRESH_INTERVAL_MS = 30_000L
     }
 }

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailLogic.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailLogic.kt
@@ -1,0 +1,32 @@
+package org.hejnaluk.metrotimetable.ui.presentation.detail
+
+import kotlin.time.Instant
+import org.hejnaluk.metrotimetable.ui.data.api.TripStop
+
+/**
+ * Returns the index of the stop representing the train's current timetable position.
+ *
+ * Rules:
+ * - Find the last stop whose [TripStop.arrivalTime] is in the past (≤ [now]).
+ *   First stops have a null [TripStop.arrivalTime] and are never counted as past.
+ * - If no stop has passed yet → highlight the first stop (index 0).
+ * - If all stops are in the past → the train has reached terminus, return null (no highlight).
+ */
+fun currentPositionIndex(stops: List<TripStop>, now: Instant): Int? {
+    val lastPastIdx = stops.indexOfLast { stop ->
+        val time = stop.arrivalTime ?: return@indexOfLast false
+        Instant.parse(time) <= now
+    }
+    return when {
+        lastPastIdx == -1 -> 0                     // all in the future → first stop
+        lastPastIdx == stops.size - 1 -> null      // all past → train at terminus
+        else -> lastPastIdx
+    }
+}
+
+/**
+ * Returns the index of the stop matching [stationName] (case-insensitive), or null if not found.
+ */
+fun selectedStationIndex(stops: List<TripStop>, stationName: String): Int? =
+    stops.indexOfFirst { it.stopName.equals(stationName, ignoreCase = true) }
+        .takeIf { it != -1 }

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailScreen.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailScreen.kt
@@ -1,0 +1,242 @@
+package org.hejnaluk.metrotimetable.ui.presentation.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.hejnaluk.metrotimetable.ui.data.api.TripStop
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TrainDetailScreen(
+    routeId: String,
+    directionId: Int,
+    departureTime: String,
+    station: String,
+    onBack: () -> Unit,
+    viewModel: TrainDetailViewModel = koinViewModel()
+) {
+    LaunchedEffect(routeId, directionId, departureTime) {
+        viewModel.start(routeId, directionId, departureTime)
+    }
+
+    val state by viewModel.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            val titleText = when (val s = state) {
+                is TrainDetailState.Success -> {
+                    val now = Clock.System.now()
+                    val currentIdx = currentPositionIndex(s.detail.stops, now)
+                    val currentStopName = currentIdx?.let { s.detail.stops[it].stopName } ?: s.detail.destination
+                    "$currentStopName → ${s.detail.destination}"
+                }
+                else -> "→ …"
+            }
+            TopAppBar(
+                title = { Text(titleText) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when (val s = state) {
+                is TrainDetailState.Loading -> CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+
+                is TrainDetailState.Error -> Text(
+                    text = "Error: ${s.message}",
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(16.dp),
+                    color = MaterialTheme.colorScheme.error
+                )
+
+                is TrainDetailState.Success -> TripStopList(
+                    stops = s.detail.stops,
+                    station = station,
+                    updatedAt = s.updatedAt
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TripStopList(
+    stops: List<TripStop>,
+    station: String,
+    updatedAt: LocalTime
+) {
+    val now = Clock.System.now()
+    val currentPositionIdx = currentPositionIndex(stops, now)
+    val selectedStationIdx = selectedStationIndex(stops, station)
+
+    val listState = rememberLazyListState()
+    val hasScrolled = remember { mutableStateOf(false) }
+
+    LaunchedEffect(stops) {
+        if (!hasScrolled.value) {
+            val scrollTarget = currentPositionIdx ?: 0
+            listState.animateScrollToItem(scrollTarget)
+            hasScrolled.value = true
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "Updated: $updatedAt",
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+        )
+        LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+            itemsIndexed(stops) { index, stop ->
+                TripStopRow(
+                    stop = stop,
+                    isCurrentPosition = index == currentPositionIdx,
+                    isSelectedStation = index == selectedStationIdx,
+                    now = now
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TripStopRow(
+    stop: TripStop,
+    isCurrentPosition: Boolean,
+    isSelectedStation: Boolean,
+    now: Instant
+) {
+    val timeInstant = (stop.arrivalTime ?: stop.departureTime)?.let { Instant.parse(it) }
+    val isPast = timeInstant != null && timeInstant < now
+    val minutesRelative = timeInstant?.let { (it - now).inWholeMinutes }
+    val localTime = timeInstant?.toLocalDateTime(TimeZone.currentSystemDefault())?.time
+
+    val timeText = localTime?.let {
+        "${it.hour.toString().padStart(2, '0')}:${it.minute.toString().padStart(2, '0')}"
+    } ?: ""
+
+    val countdownText = minutesRelative?.let {
+        when {
+            it in -1..1 -> "Now"
+            it > 0 -> "in $it min"
+            else -> "${-it} min ago"
+        }
+    } ?: ""
+
+    val dimmed = isPast && !isCurrentPosition && !isSelectedStation
+    val containerColor = when {
+        isCurrentPosition -> MaterialTheme.colorScheme.primaryContainer
+        else -> MaterialTheme.colorScheme.surfaceVariant
+    }
+
+    val outerModifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp, vertical = 3.dp)
+        .let { m ->
+            if (isSelectedStation) m.border(2.dp, MaterialTheme.colorScheme.secondary, RoundedCornerShape(8.dp))
+            else m
+        }
+
+    Surface(
+        modifier = outerModifier,
+        shape = RoundedCornerShape(8.dp),
+        color = containerColor
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    if (dimmed) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                    else containerColor
+                )
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stop.stopName,
+                style = if (isCurrentPosition)
+                    MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                else
+                    MaterialTheme.typography.bodyLarge,
+                color = if (dimmed)
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                else
+                    MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 8.dp)
+            )
+            Column(horizontalAlignment = Alignment.End) {
+                if (timeText.isNotEmpty()) {
+                    Text(
+                        text = timeText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (dimmed)
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                        else
+                            MaterialTheme.colorScheme.onSurface
+                    )
+                }
+                if (countdownText.isNotEmpty()) {
+                    Text(
+                        text = countdownText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (dimmed)
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                        else
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailState.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailState.kt
@@ -1,0 +1,13 @@
+package org.hejnaluk.metrotimetable.ui.presentation.detail
+
+import kotlinx.datetime.LocalTime
+import org.hejnaluk.metrotimetable.ui.data.api.TripDetail
+
+sealed class TrainDetailState {
+    data object Loading : TrainDetailState()
+    data class Success(
+        val detail: TripDetail,
+        val updatedAt: LocalTime
+    ) : TrainDetailState()
+    data class Error(val message: String) : TrainDetailState()
+}

--- a/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailViewModel.kt
+++ b/ui/composeApp/src/commonMain/kotlin/org/hejnaluk/metrotimetable/ui/presentation/detail/TrainDetailViewModel.kt
@@ -1,0 +1,41 @@
+package org.hejnaluk.metrotimetable.ui.presentation.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.hejnaluk.metrotimetable.ui.currentLocalTime
+import org.hejnaluk.metrotimetable.ui.data.AppConfigStore
+import org.hejnaluk.metrotimetable.ui.data.MetroRepository
+
+class TrainDetailViewModel(
+    private val repository: MetroRepository,
+    private val appConfigStore: AppConfigStore
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<TrainDetailState>(TrainDetailState.Loading)
+    val state: StateFlow<TrainDetailState> = _state.asStateFlow()
+
+    fun start(routeId: String, directionId: Int, departureTime: String) {
+        viewModelScope.launch {
+            while (true) {
+                load(routeId, directionId, departureTime)
+                delay(appConfigStore.config.value.tripDetailRefreshIntervalSeconds * 1_000L)
+            }
+        }
+    }
+
+    private suspend fun load(routeId: String, directionId: Int, departureTime: String) {
+        repository.fetchTripDetail(routeId, directionId, departureTime).fold(
+            onSuccess = { detail ->
+                _state.value = TrainDetailState.Success(detail, currentLocalTime())
+            },
+            onFailure = { error ->
+                _state.value = TrainDetailState.Error(error.message ?: "Unknown error")
+            }
+        )
+    }
+}

--- a/ui/composeApp/src/commonTest/kotlin/org/hejnaluk/metrotimetable/ui/TrainDetailLogicTest.kt
+++ b/ui/composeApp/src/commonTest/kotlin/org/hejnaluk/metrotimetable/ui/TrainDetailLogicTest.kt
@@ -1,0 +1,100 @@
+package org.hejnaluk.metrotimetable.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+import org.hejnaluk.metrotimetable.ui.data.api.TripStop
+import org.hejnaluk.metrotimetable.ui.presentation.detail.currentPositionIndex
+import org.hejnaluk.metrotimetable.ui.presentation.detail.selectedStationIndex
+
+class TrainDetailLogicTest {
+
+    private val t10 = "2026-04-17T10:00:00Z"
+    private val t11 = "2026-04-17T11:00:00Z"
+    private val t12 = "2026-04-17T12:00:00Z"
+    private val t13 = "2026-04-17T13:00:00Z"
+    private val t14 = "2026-04-17T14:00:00Z"
+
+    /** Builds a simple stop with the given arrival (null for index 0) and departure (null for last). */
+    private fun stop(name: String, arrival: String?, departure: String?) =
+        TripStop(stopName = name, arrivalTime = arrival, departureTime = departure)
+
+    @Test
+    fun currentPositionIndex_isLastStopWithArrivalTimeInPast() {
+        val stops = listOf(
+            stop("A", null, t10),    // first stop — arrivalTime null, never counts as past
+            stop("B", t11, t11),     // arrivalTime 11:00, past at 12:30
+            stop("C", t12, t12),     // arrivalTime 12:00, past at 12:30
+            stop("D", t13, t13),     // arrivalTime 13:00, future at 12:30
+            stop("E", t14, null)     // last stop
+        )
+        val now = Instant.parse("2026-04-17T12:30:00Z")
+
+        val result = currentPositionIndex(stops, now)
+
+        assertEquals(2, result)  // C is the last stop with arrivalTime in the past
+    }
+
+    @Test
+    fun currentPositionIndex_isFirstStop_whenAllStopsAreInFuture() {
+        val stops = listOf(
+            stop("A", null, t13),    // first stop — arrivalTime null
+            stop("B", t13, t13),
+            stop("C", t14, null)     // last stop
+        )
+        val now = Instant.parse("2026-04-17T12:00:00Z")  // before all arrivalTimes
+
+        val result = currentPositionIndex(stops, now)
+
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun currentPositionIndex_isNull_whenAllStopsAreInPast() {
+        val stops = listOf(
+            stop("A", null, t10),
+            stop("B", t10, t11),
+            stop("C", t11, null)     // last stop — arrivalTime 11:00 is in the past
+        )
+        val now = Instant.parse("2026-04-17T13:00:00Z")  // after all arrivalTimes
+
+        val result = currentPositionIndex(stops, now)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun selectedStationIndex_matchesPassedStationName() {
+        val stops = listOf(
+            stop("Depo Hostivař", null, t10),
+            stop("Muzeum", t11, t11),
+            stop("Zličín", t12, null)
+        )
+
+        val result = selectedStationIndex(stops, "Muzeum")
+
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun selectedStationIndex_isCaseInsensitive() {
+        val stops = listOf(
+            stop("Depo Hostivař", null, t10),
+            stop("Muzeum", t11, null)
+        )
+
+        assertEquals(1, selectedStationIndex(stops, "muzeum"))
+        assertEquals(1, selectedStationIndex(stops, "MUZEUM"))
+    }
+
+    @Test
+    fun selectedStationIndex_isNull_whenStationNotInList() {
+        val stops = listOf(
+            stop("Depo Hostivař", null, t10),
+            stop("Muzeum", t11, null)
+        )
+
+        assertNull(selectedStationIndex(stops, "Zličín"))
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Expose detailed train trip information from the backend and surface it in the UI via a new train detail screen, driven by server-configurable refresh intervals.

New Features:
- Add backend endpoint to return detailed trip information (route, direction, destination, and full stop list) and expose it via new TripDetail/TripStop DTOs.
- Introduce a UI train detail screen navigated from departures, showing the full stop sequence with current position and selected station highlighting.
- Add an AppConfig endpoint and client-side store so UI refresh intervals for departures and trip detail are configured by the server and polled periodically.

Enhancements:
- Extend timetable parsing service to derive full trip details from cached GTFS trips, including correct handling of first/last stop times and post-midnight trips.

Tests:
- Add controller and service tests covering trip detail retrieval, validation, not-found behavior, and configuration values.
- Add UI logic tests for determining the train's current position and selected station in the trip detail view.