### PR TITLE
Add trip detail metric and some more metrics

### DIFF
--- a/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
@@ -44,6 +44,11 @@ public class PIDClient {
     private final File folder;
     private final MeterRegistry meterRegistry;
 
+    private final Timer downloadTimer;
+    private final Counter downloadSkippedCounter;
+    private final Counter downloadSuccessCounter;
+    private final Counter downloadFailureCounter;
+
     @Autowired
     public PIDClient(@Value("${pid.client.path:''}") String pathToFile, MeterRegistry meterRegistry) {
         this.pathToFile = pathToFile;
@@ -64,6 +69,13 @@ public class PIDClient {
                 log.error("Failed to create folder {}", folder.getAbsolutePath());
             }
         }
+
+        downloadTimer = Timer.builder("gtfs.download.duration")
+                .description("Time taken to download the GTFS ZIP from the remote source")
+                .register(meterRegistry);
+        downloadSkippedCounter = downloadCounter("skipped");
+        downloadSuccessCounter = downloadCounter("success");
+        downloadFailureCounter = downloadCounter("failure");
     }
 
     /**
@@ -75,14 +87,11 @@ public class PIDClient {
         log.info("PIDClient address is: {}", pathToFile);
         if (!isDoClientCall()) {
             log.info("Client call is not needed");
-            downloadCounter("skipped").increment();
+            downloadSkippedCounter.increment();
             return false;
         }
 
         try {
-            Timer downloadTimer = Timer.builder("gtfs.download.duration")
-                    .description("Time taken to download the GTFS ZIP from the remote source")
-                    .register(meterRegistry);
             Timer.Sample downloadSample = Timer.start();
             byte[] zipData = restClient.get()
                     .header(HttpHeaders.ACCEPT, "application/zip")
@@ -99,10 +108,10 @@ public class PIDClient {
 
             writeSuccessful();
             log.info("All files are downloaded and extracted successfully in memory!");
-            downloadCounter("success").increment();
+            downloadSuccessCounter.increment();
             return true;
         } catch (Exception e) {
-            downloadCounter("failure").increment();
+            downloadFailureCounter.increment();
             throw e;
         }
     }

--- a/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
@@ -1,5 +1,7 @@
 package org.hejnaluk.metrotimetable.client;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.hejnaluk.metrotimetable.exception.WriteSyncFileException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,10 +41,12 @@ public class PIDClient {
     private final String pathToFile;
     private final RestClient restClient;
     private final File folder;
+    private final MeterRegistry meterRegistry;
 
     @Autowired
-    public PIDClient(@Value("${pid.client.path:''}") String pathToFile) {
+    public PIDClient(@Value("${pid.client.path:''}") String pathToFile, MeterRegistry meterRegistry) {
         this.pathToFile = pathToFile;
+        this.meterRegistry = meterRegistry;
         log.info("Init PIDClient address is: {}", pathToFile);
         this.restClient = RestClient.builder()
                 .baseUrl(pathToFile)
@@ -73,10 +77,15 @@ public class PIDClient {
             return false;
         }
 
+        Timer downloadTimer = Timer.builder("gtfs.download.duration")
+                .description("Time taken to download the GTFS ZIP from the remote source")
+                .register(meterRegistry);
+        Timer.Sample downloadSample = Timer.start();
         byte[] zipData = restClient.get()
                 .header(HttpHeaders.ACCEPT, "application/zip")
                 .retrieve()
                 .body(byte[].class);
+        downloadSample.stop(downloadTimer);
 
         log.info("Received ZIP file of size: {}", Optional.ofNullable(zipData).map(data -> data.length).orElse(0));
         extractZip(zipData);

--- a/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
@@ -1,5 +1,6 @@
 package org.hejnaluk.metrotimetable.client;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
@@ -74,29 +75,43 @@ public class PIDClient {
         log.info("PIDClient address is: {}", pathToFile);
         if (!isDoClientCall()) {
             log.info("Client call is not needed");
+            downloadCounter("skipped").increment();
             return false;
         }
 
-        Timer downloadTimer = Timer.builder("gtfs.download.duration")
-                .description("Time taken to download the GTFS ZIP from the remote source")
+        try {
+            Timer downloadTimer = Timer.builder("gtfs.download.duration")
+                    .description("Time taken to download the GTFS ZIP from the remote source")
+                    .register(meterRegistry);
+            Timer.Sample downloadSample = Timer.start();
+            byte[] zipData = restClient.get()
+                    .header(HttpHeaders.ACCEPT, "application/zip")
+                    .retrieve()
+                    .body(byte[].class);
+            downloadSample.stop(downloadTimer);
+
+            log.info("Received ZIP file of size: {}", Optional.ofNullable(zipData).map(data -> data.length).orElse(0));
+            extractZip(zipData);
+            log.info("ZIP extraction completed");
+
+            filterStopTimes();
+            log.info("stop_times.txt pre-filtered");
+
+            writeSuccessful();
+            log.info("All files are downloaded and extracted successfully in memory!");
+            downloadCounter("success").increment();
+            return true;
+        } catch (Exception e) {
+            downloadCounter("failure").increment();
+            throw e;
+        }
+    }
+
+    private Counter downloadCounter(String result) {
+        return Counter.builder("gtfs.download.total")
+                .description("Number of GTFS download attempts by result")
+                .tag("result", result)
                 .register(meterRegistry);
-        Timer.Sample downloadSample = Timer.start();
-        byte[] zipData = restClient.get()
-                .header(HttpHeaders.ACCEPT, "application/zip")
-                .retrieve()
-                .body(byte[].class);
-        downloadSample.stop(downloadTimer);
-
-        log.info("Received ZIP file of size: {}", Optional.ofNullable(zipData).map(data -> data.length).orElse(0));
-        extractZip(zipData);
-        log.info("ZIP extraction completed");
-
-        filterStopTimes();
-        log.info("stop_times.txt pre-filtered");
-
-        writeSuccessful();
-        log.info("All files are downloaded and extracted successfully in memory!");
-        return true;
     }
 
     /**

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
@@ -184,7 +184,15 @@ public class ParseTimetableService {
     }
 
     private volatile TimetableData timetableData = TimetableData.empty();
+    /** Advanced only on a successful parse; reads from the cache-age gauge reflect the last good refresh. */
     private volatile Instant lastRefreshTime = Instant.EPOCH;
+
+    private Timer fileParseTimer;
+    private Timer cacheBuildTimer;
+    private Timer stationQueryFoundTimer;
+    private Timer stationQueryNotFoundTimer;
+    private Timer tripQueryFoundTimer;
+    private Timer tripQueryNotFoundTimer;
 
     @PostConstruct
     void registerGauges() {
@@ -195,6 +203,29 @@ public class ParseTimetableService {
         Gauge.builder("timetable.cache.trips.total", this,
                         s -> s.timetableData.routeCache().values().stream().mapToInt(Map::size).sum())
                 .description("Total number of trips currently loaded in the route cache")
+                .register(meterRegistry);
+
+        fileParseTimer = Timer.builder("file.parse")
+                .description("Time taken to parse files")
+                .register(meterRegistry);
+        cacheBuildTimer = Timer.builder("create.cache")
+                .description("Time taken to create cache")
+                .register(meterRegistry);
+        stationQueryFoundTimer = Timer.builder("station.query")
+                .description("Time taken to query trains for a station")
+                .tag("found", "true")
+                .register(meterRegistry);
+        stationQueryNotFoundTimer = Timer.builder("station.query")
+                .description("Time taken to query trains for a station")
+                .tag("found", "false")
+                .register(meterRegistry);
+        tripQueryFoundTimer = Timer.builder("trip.query")
+                .description("Time taken to look up a trip detail")
+                .tag("found", "true")
+                .register(meterRegistry);
+        tripQueryNotFoundTimer = Timer.builder("trip.query")
+                .description("Time taken to look up a trip detail")
+                .tag("found", "false")
                 .register(meterRegistry);
     }
 
@@ -211,10 +242,7 @@ public class ParseTimetableService {
      */
     public void parseTimetableFiles() {
         log.info("----------------------- PARSING START ------------------------");
-        io.micrometer.core.instrument.Timer fileParseTimer = io.micrometer.core.instrument.Timer.builder("file.parse")
-                .description("Time taken to parse files")
-                .register(meterRegistry);
-        io.micrometer.core.instrument.Timer.Sample fileParseTimeSample = Timer.start();
+        Timer.Sample fileParseTimeSample = Timer.start();
 
         // Phase 1: Determine active services synchronously (two small files, ~ms),
         // then parse route stop IDs and trips in parallel.
@@ -239,10 +267,7 @@ public class ParseTimetableService {
         log.info("----------------------- PARSING DONE ------------------------");
 
         log.info("------------------------ CACHE START ------------------------");
-        io.micrometer.core.instrument.Timer cacheBuildTimer = io.micrometer.core.instrument.Timer.builder("create.cache")
-                .description("Time taken to create cache")
-                .register(meterRegistry);
-        io.micrometer.core.instrument.Timer.Sample cacheBuildTimeSample = Timer.start();
+        Timer.Sample cacheBuildTimeSample = Timer.start();
 
         // Stream stop_times.txt trip-by-trip directly into the cache.
         // ASSUMPTION: rows are sorted by trip_id (standard GTFS ordering from PID).
@@ -329,7 +354,7 @@ public class ParseTimetableService {
         final TimetableData snapshot = timetableData;
         final Map<String, Integer> keyToStopIndex = snapshot.stationIndex().get(stationName.toLowerCase());
         if (keyToStopIndex == null) {
-            sample.stop(stationQueryTimer(false));
+            sample.stop(stationQueryNotFoundTimer);
             return List.of();
         }
 
@@ -344,15 +369,8 @@ public class ParseTimetableService {
                 .limit(effectiveLimit)
                 .toList();
 
-        sample.stop(stationQueryTimer(!result.isEmpty()));
+        sample.stop(result.isEmpty() ? stationQueryNotFoundTimer : stationQueryFoundTimer);
         return result;
-    }
-
-    private Timer stationQueryTimer(boolean found) {
-        return Timer.builder("station.query")
-                .description("Time taken to query trains for a station")
-                .tag("found", String.valueOf(found))
-                .register(meterRegistry);
     }
 
     /**
@@ -462,7 +480,7 @@ public class ParseTimetableService {
         final String key = routeId + "-" + directionId;
         final ConcurrentSkipListMap<LocalTime, List<CompleteStop>> trips = snapshot.routeCache().get(key);
         if (trips == null) {
-            sample.stop(tripQueryTimer(false));
+            sample.stop(tripQueryNotFoundTimer);
             return Optional.empty();
         }
 
@@ -486,15 +504,8 @@ public class ParseTimetableService {
                     return new TripDetail(routeId, directionId, stops.getLast().stop().stopName(), tripStops);
                 });
 
-        sample.stop(tripQueryTimer(result.isPresent()));
+        sample.stop(result.isPresent() ? tripQueryFoundTimer : tripQueryNotFoundTimer);
         return result;
-    }
-
-    private Timer tripQueryTimer(boolean found) {
-        return Timer.builder("trip.query")
-                .description("Time taken to look up a trip detail")
-                .tag("found", String.valueOf(found))
-                .register(meterRegistry);
     }
 
     // --- Package-private test support ---

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
@@ -306,16 +306,13 @@ public class ParseTimetableService {
      * @return list of upcoming {@link TrainDeparture}s sorted by departure time, or an empty list if the station is not found
      */
     public List<TrainDeparture> getTrainsForStation(String stationName, Integer direction, int limit, String routeId) {
-        Timer timer = Timer.builder("station.query")
-                .description("Time taken to query trains for a station")
-                .register(meterRegistry);
         Timer.Sample sample = Timer.start();
 
         // Snapshot once — guarantees a consistent route cache + station index pair.
         final TimetableData snapshot = timetableData;
         final Map<String, Integer> keyToStopIndex = snapshot.stationIndex().get(stationName.toLowerCase());
         if (keyToStopIndex == null) {
-            sample.stop(timer);
+            sample.stop(stationQueryTimer(false));
             return List.of();
         }
 
@@ -330,8 +327,15 @@ public class ParseTimetableService {
                 .limit(effectiveLimit)
                 .toList();
 
-        sample.stop(timer);
+        sample.stop(stationQueryTimer(!result.isEmpty()));
         return result;
+    }
+
+    private Timer stationQueryTimer(boolean found) {
+        return Timer.builder("station.query")
+                .description("Time taken to query trains for a station")
+                .tag("found", String.valueOf(found))
+                .register(meterRegistry);
     }
 
     /**
@@ -435,15 +439,20 @@ public class ParseTimetableService {
      * @return the {@link TripDetail} if a matching trip is found, or {@link Optional#empty()} if not
      */
     public Optional<TripDetail> getTripDetail(String routeId, int directionId, Instant departureTime) {
+        Timer.Sample sample = Timer.start();
+
         final TimetableData snapshot = timetableData;
         final String key = routeId + "-" + directionId;
         final ConcurrentSkipListMap<LocalTime, List<CompleteStop>> trips = snapshot.routeCache().get(key);
-        if (trips == null) return Optional.empty();
+        if (trips == null) {
+            sample.stop(tripQueryTimer(false));
+            return Optional.empty();
+        }
 
         final LocalTime targetTime = departureTime.atZone(PRAGUE_ZONE).toLocalTime();
         final LocalDate today = getToday();
 
-        return trips.values().stream()
+        Optional<TripDetail> result = trips.values().stream()
                 .filter(stops -> stops.stream()
                         .anyMatch(s -> s.departureTime().equals(targetTime) || s.arrivalTime().equals(targetTime)))
                 .findFirst()
@@ -459,6 +468,16 @@ public class ParseTimetableService {
                     }
                     return new TripDetail(routeId, directionId, stops.getLast().stop().stopName(), tripStops);
                 });
+
+        sample.stop(tripQueryTimer(result.isPresent()));
+        return result;
+    }
+
+    private Timer tripQueryTimer(boolean found) {
+        return Timer.builder("trip.query")
+                .description("Time taken to look up a trip detail")
+                .tag("found", String.valueOf(found))
+                .register(meterRegistry);
     }
 
     // --- Package-private test support ---

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
@@ -1,7 +1,9 @@
 package org.hejnaluk.metrotimetable.service;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -181,6 +184,19 @@ public class ParseTimetableService {
     }
 
     private volatile TimetableData timetableData = TimetableData.empty();
+    private volatile Instant lastRefreshTime = Instant.EPOCH;
+
+    @PostConstruct
+    void registerGauges() {
+        Gauge.builder("timetable.cache.age.seconds", this,
+                        s -> Duration.between(s.lastRefreshTime, Instant.now()).toSeconds())
+                .description("Seconds since the last successful timetable parse")
+                .register(meterRegistry);
+        Gauge.builder("timetable.cache.trips.total", this,
+                        s -> s.timetableData.routeCache().values().stream().mapToInt(Map::size).sum())
+                .description("Total number of trips currently loaded in the route cache")
+                .register(meterRegistry);
+    }
 
     /**
      * Downloads (if stale), parses all GTFS files, and atomically replaces the in-memory cache.
@@ -252,6 +268,7 @@ public class ParseTimetableService {
 
         // Atomic swap: readers always see a complete, consistent snapshot.
         timetableData = new TimetableData(newRouteCache, newStationIndex);
+        lastRefreshTime = Instant.now();
 
         cacheBuildTimeSample.stop(cacheBuildTimer);
         log.info("------------------------ CACHE DONE: {} route-direction keys, {} stations ------------------------",

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/TimetableRefreshService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/TimetableRefreshService.java
@@ -1,5 +1,7 @@
 package org.hejnaluk.metrotimetable.service;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hejnaluk.metrotimetable.client.PIDClient;
@@ -15,6 +17,7 @@ public class TimetableRefreshService {
 
     private final PIDClient pidClient;
     private final ParseTimetableService parseTimetableService;
+    private final MeterRegistry meterRegistry;
 
     /**
      * Warm the cache on startup. Always parses after startup regardless of whether new data
@@ -23,8 +26,14 @@ public class TimetableRefreshService {
     @EventListener(ApplicationReadyEvent.class)
     public void onStartup() {
         log.info("Application ready — warming timetable cache");
-        pidClient.getData();
-        parseTimetableService.parseTimetableFiles();
+        try {
+            pidClient.getData();
+            parseTimetableService.parseTimetableFiles();
+            refreshCounter("startup", "success").increment();
+        } catch (Exception e) {
+            refreshCounter("startup", "failure").increment();
+            throw e;
+        }
     }
 
     /**
@@ -36,11 +45,17 @@ public class TimetableRefreshService {
     @Scheduled(cron = "${pid.refresh.cron:0 0 4 * * *}")
     public void scheduledRefresh() {
         log.info("Scheduled timetable refresh triggered");
-        boolean newData = pidClient.getData();
-        if (newData) {
-            parseTimetableService.parseTimetableFiles();
-        } else {
-            log.info("No new GTFS data — skipping parse");
+        try {
+            boolean newData = pidClient.getData();
+            if (newData) {
+                parseTimetableService.parseTimetableFiles();
+            } else {
+                log.info("No new GTFS data — skipping parse");
+            }
+            refreshCounter("scheduled", "success").increment();
+        } catch (Exception e) {
+            refreshCounter("scheduled", "failure").increment();
+            throw e;
         }
     }
 
@@ -49,7 +64,21 @@ public class TimetableRefreshService {
      * Called by the manual refresh endpoint.
      */
     public void refresh() {
-        pidClient.getData();
-        parseTimetableService.parseTimetableFiles();
+        try {
+            pidClient.getData();
+            parseTimetableService.parseTimetableFiles();
+            refreshCounter("manual", "success").increment();
+        } catch (Exception e) {
+            refreshCounter("manual", "failure").increment();
+            throw e;
+        }
+    }
+
+    private Counter refreshCounter(String trigger, String outcome) {
+        return Counter.builder("timetable.refresh.total")
+                .description("Number of timetable refresh attempts by trigger and outcome")
+                .tag("trigger", trigger)
+                .tag("outcome", outcome)
+                .register(meterRegistry);
     }
 }

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/TimetableRefreshService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/TimetableRefreshService.java
@@ -2,6 +2,7 @@ package org.hejnaluk.metrotimetable.service;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hejnaluk.metrotimetable.client.PIDClient;
@@ -9,6 +10,10 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +23,21 @@ public class TimetableRefreshService {
     private final PIDClient pidClient;
     private final ParseTimetableService parseTimetableService;
     private final MeterRegistry meterRegistry;
+
+    private final Map<String, Counter> refreshCounters = new HashMap<>();
+
+    @PostConstruct
+    void registerMetrics() {
+        for (String trigger : List.of("startup", "scheduled", "manual")) {
+            for (String outcome : List.of("success", "failure")) {
+                refreshCounters.put(trigger + "." + outcome, Counter.builder("timetable.refresh.total")
+                        .description("Number of timetable refresh attempts by trigger and outcome")
+                        .tag("trigger", trigger)
+                        .tag("outcome", outcome)
+                        .register(meterRegistry));
+            }
+        }
+    }
 
     /**
      * Warm the cache on startup. Always parses after startup regardless of whether new data
@@ -75,10 +95,6 @@ public class TimetableRefreshService {
     }
 
     private Counter refreshCounter(String trigger, String outcome) {
-        return Counter.builder("timetable.refresh.total")
-                .description("Number of timetable refresh attempts by trigger and outcome")
-                .tag("trigger", trigger)
-                .tag("outcome", outcome)
-                .register(meterRegistry);
+        return refreshCounters.get(trigger + "." + outcome);
     }
 }

--- a/server/src/test/java/org/hejnaluk/metrotimetable/client/PIDClientTest.java
+++ b/server/src/test/java/org/hejnaluk/metrotimetable/client/PIDClientTest.java
@@ -16,6 +16,8 @@ import java.time.ZonedDateTime;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class PIDClientTest {
@@ -30,7 +32,7 @@ class PIDClientTest {
     void setUp() throws IOException {
         server = new MockWebServer();
         server.start();
-        client = new PIDClient("http://localhost:" + server.getPort());
+        client = new PIDClient("http://localhost:" + server.getPort(), new SimpleMeterRegistry());
         Files.deleteIfExists(SYNC_FILE);
         Files.deleteIfExists(EXTRACTED_FILE);
     }

--- a/server/src/test/java/org/hejnaluk/metrotimetable/service/ParseTimetableServiceTest.java
+++ b/server/src/test/java/org/hejnaluk/metrotimetable/service/ParseTimetableServiceTest.java
@@ -62,6 +62,7 @@ class ParseTimetableServiceTest {
                 return FIXTURE_DIR;
             }
         };
+        service.registerGauges();
         setMaxLimit(service, 15);
         service.resetForTest();
     }


### PR DESCRIPTION
## Summary by Sourcery

Add observability metrics around GTFS downloads, timetable parsing, cache state, and query operations to improve monitoring and diagnostics.

Enhancements:
- Track GTFS ZIP download duration and outcome using timers and tagged counters in the PID client.
- Expose gauges for timetable cache age and total loaded trips in the parsing service.
- Record station and trip query latencies with success/found tagging for better request-level visibility.
- Count timetable refresh attempts by trigger type (startup, scheduled, manual) and outcome (success, failure) via tagged counters.
- Inject the metrics registry into relevant services to support the new monitoring instrumentation.