### PR TITLE
Add histograms for new metrics

### DIFF
--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
@@ -200,7 +200,7 @@ public class ParseTimetableService {
                         s -> Duration.between(s.lastRefreshTime, Instant.now()).toSeconds())
                 .description("Seconds since the last successful timetable parse")
                 .register(meterRegistry);
-        Gauge.builder("timetable.cache.trips.total", this,
+        Gauge.builder("timetable.cache.trips", this,
                         s -> s.timetableData.routeCache().values().stream().mapToInt(Map::size).sum())
                 .description("Total number of trips currently loaded in the route cache")
                 .register(meterRegistry);

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -15,9 +15,10 @@ management.endpoints.web.exposure.include=prometheus
 management.endpoint.prometheus.enabled=true
 management.metrics.distribution.percentiles-histogram.http.server.requests: true
 management.metrics.distribution.percentiles-histogram.create.cache: true
-management.metrics.distribution.percentiles-histogram.create.releationship: true
 management.metrics.distribution.percentiles-histogram.file.parse: true
 management.metrics.distribution.percentiles-histogram.station.query: true
+management.metrics.distribution.percentiles-histogram.trip.query: true
+management.metrics.distribution.percentiles-histogram.gtfs.download.duration: true
 
 pid.client.station.max-limit=15
 


### PR DESCRIPTION
## Summary by Sourcery

Enable additional metrics histograms and adjust a gauge metric name for timetable trip cache.

New Features:
- Add percentile histograms for trip query and GTFS download duration metrics.

Enhancements:
- Rename the timetable trips cache gauge metric to a more general name.