### PR TITLE
Add logback dependency and logback config file

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -51,6 +51,12 @@
         </dependency>
 
         <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>8.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<configuration>
+  <springProfile name="dev">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+      </encoder>
+    </appender>
+    <root level="INFO"><appender-ref ref="CONSOLE"/></root>
+  </springProfile>
+
+  <springProfile name="!dev">
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+    <root level="INFO"><appender-ref ref="JSON"/></root>
+  </springProfile>
+</configuration>


### PR DESCRIPTION
## Summary by Sourcery

Configure environment-specific Logback logging with JSON output outside dev and add the Logstash Logback encoder dependency.

Build:
- Add net.logstash.logback:logstash-logback-encoder dependency to the server module.

Deployment:
- Introduce a Logback Spring configuration that logs plain text to console in dev and JSON to console using Logstash encoder in non-dev profiles.