### PR TITLE
Update README.md file with latest monitoring stack changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,20 +176,50 @@ The dashboard JSON is at `grafana-dashboard/grafana.json`. Import it via **Dashb
 
 ### Local access
 
-To open Grafana against a local minikube cluster:
+To open Grafana against a local or remote cluster without an ingress:
 
 ```bash
-./port-forward-grafana.sh        # serves on http://localhost:3000
+./port-forward-grafana.sh        # serves on http://localhost:3001
 ./port-forward-grafana.sh 8080   # custom port
 ```
 
 Login: `admin` / `admin`.
 
-In production Grafana is exposed at `https://hejnaluk.dev/grafana` via a TLS ingress (`k8s/monitoring/grafana-ingress.yaml`).
+In production Grafana is exposed at `https://hejnaluk.dev/grafana` via a Traefik TLS ingress backed by a cert-manager `letsencrypt-prod` certificate.
 
-### Prometheus stack setup
+### Monitoring stack setup
 
-The monitoring stack (Prometheus Operator + Grafana) is expected to be installed in the `monitoring` namespace via the `kube-prometheus-stack` Helm chart. The `ServiceMonitor` carries the label `release: prometheus` so it is picked up by the operator automatically.
+The monitoring stack lives in a separate directory (`monitoring/k8s/`, outside this repo). It bundles:
+
+| Component | Role |
+|---|---|
+| `kube-prometheus-stack` | Prometheus Operator + Grafana + Alertmanager |
+| Loki (SingleBinary) | Log aggregation; filesystem storage, 30-day retention |
+| Promtail | Log shipper — collects pod logs and forwards them to Loki |
+
+Grafana is pre-configured with Loki as an additional data source, so metrics and logs are available in the same UI.
+
+**Deploy the stack:**
+
+```bash
+cd monitoring/k8s
+
+# Local (minikube) — port-forwards Grafana on http://localhost:3000 after install
+./deploy.sh --env local
+
+# Production (k3s on VPS) — applies TLS ingress at https://hejnaluk.dev/grafana
+./deploy.sh --env prod
+```
+
+The script installs/upgrades all three Helm releases in the `monitoring` namespace, then generates and applies Grafana dashboard ConfigMaps.
+
+**Dashboard workflow:**
+
+Dashboard JSON files live in `monitoring/k8s/dashboards/` (e.g. `metro-timetable.json`). `deploy.sh` converts each JSON to a Kubernetes ConfigMap via `dashboard-to-configmap.sh` and labels it `grafana_dashboard: "1"`. The `grafana-sc-dashboard` sidecar inside the Grafana pod watches for ConfigMaps with that label and loads them automatically; `deploy.sh` also restarts Grafana after applying changes to ensure they take effect.
+
+To update a dashboard: edit the JSON in `dashboards/`, then re-run `deploy.sh`.
+
+**ServiceMonitor:** Each project (including this one) applies its own `ServiceMonitor` pointing at this stack. The `ServiceMonitor` in `server/k8s/base/servicemonitor.yaml` carries the label `release: prometheus` so the Prometheus Operator picks it up automatically.
 
 ## UI (Kotlin Multiplatform)
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The dashboard JSON is at `grafana-dashboard/grafana.json`. Import it via **Dashb
 
 ### Local access
 
-To open Grafana against a local or remote cluster without an ingress:
+`deploy.sh --env local` automatically starts a blocking port-forward on `http://localhost:3000` after the install completes. To reconnect later (without re-running the full deploy), use the standalone script instead:
 
 ```bash
 ./port-forward-grafana.sh        # serves on http://localhost:3001
@@ -189,7 +189,14 @@ In production Grafana is exposed at `https://hejnaluk.dev/grafana` via a Traefik
 
 ### Monitoring stack setup
 
-The monitoring stack lives in a separate directory (`monitoring/k8s/`, outside this repo). It bundles:
+The monitoring stack lives in a separate repository — [github.com/kejhy93/monitoring](https://github.com/kejhy93/monitoring) — under the `k8s/` directory. Clone it alongside this repo before running the commands below.
+
+```bash
+git clone git@github.com:kejhy93/monitoring.git
+cd monitoring/k8s
+```
+
+It bundles:
 
 | Component | Role |
 |---|---|


### PR DESCRIPTION
## Summary by Sourcery

Document the updated Kubernetes monitoring stack layout and deployment workflow, including Loki/Promtail integration and revised Grafana access details.

Documentation:
- Clarify Grafana local and production access, including updated port and Traefik/cert-manager TLS ingress details.
- Describe the external monitoring/k8s directory, its Helm-based components (kube-prometheus-stack, Loki, Promtail), and how they integrate.
- Add deployment instructions for local and production monitoring environments via deploy.sh, including namespace and dashboard ConfigMap behavior.
- Explain the dashboard JSON to ConfigMap workflow and how ServiceMonitor resources link projects to the shared monitoring stack.