### PR TITLE
Apply sonar issues fix

### DIFF
--- a/server/src/main/java/org/hejnaluk/metrotimetable/MetroTimetableApplication.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/MetroTimetableApplication.java
@@ -2,10 +2,12 @@ package org.hejnaluk.metrotimetable;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@ConfigurationPropertiesScan
 public class MetroTimetableApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
@@ -4,9 +4,9 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
+import org.hejnaluk.metrotimetable.config.PidClientProperties;
 import org.hejnaluk.metrotimetable.exception.WriteSyncFileException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -32,14 +32,9 @@ public class PIDClient {
 
     public static final String SYNCHRONIZED_FILE_NAME = "synchronized.txt";
 
-    @Value("${pid.client.days.offset:7}")
-    private int daysOffset;
-
-    @Value("${pid.client.routes.ids:}")
-    private Set<String> routeIds;
-
+    private final int daysOffset;
+    private final Set<String> routeIds;
     private final String pathToFile;
-    private final String rootPath;
     private final RestClient restClient;
     private final File folder;
     private final MeterRegistry meterRegistry;
@@ -50,19 +45,17 @@ public class PIDClient {
     private final Counter downloadFailureCounter;
 
     @Autowired
-    public PIDClient(
-            @Value("${pid.client.path:''}") String pathToFile,
-            @Value("${pid.client.root.path:/tmp/timetable/}") String rootPath,
-            MeterRegistry meterRegistry) {
-        this.pathToFile = pathToFile;
-        this.rootPath = rootPath;
+    public PIDClient(PidClientProperties properties, MeterRegistry meterRegistry) {
+        this.pathToFile = properties.getPath();
+        this.daysOffset = properties.getDaysOffset();
+        this.routeIds = properties.getRouteIds();
         this.meterRegistry = meterRegistry;
         log.info("Init PIDClient address is: {}", pathToFile);
         this.restClient = RestClient.builder()
                 .baseUrl(pathToFile)
                 .build();
 
-        folder = Paths.get(rootPath).toFile();
+        folder = Paths.get(properties.getRootPath()).toFile();
         if (folder.exists() && folder.isDirectory()) {
             log.info("Folder {} exists", folder.getAbsolutePath());
         } else {

--- a/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/client/PIDClient.java
@@ -31,7 +31,6 @@ import java.util.zip.ZipInputStream;
 public class PIDClient {
 
     public static final String SYNCHRONIZED_FILE_NAME = "synchronized.txt";
-    public static final String ROOT_PATH_FILE = "/tmp/timetable/";
 
     @Value("${pid.client.days.offset:7}")
     private int daysOffset;
@@ -40,6 +39,7 @@ public class PIDClient {
     private Set<String> routeIds;
 
     private final String pathToFile;
+    private final String rootPath;
     private final RestClient restClient;
     private final File folder;
     private final MeterRegistry meterRegistry;
@@ -50,15 +50,19 @@ public class PIDClient {
     private final Counter downloadFailureCounter;
 
     @Autowired
-    public PIDClient(@Value("${pid.client.path:''}") String pathToFile, MeterRegistry meterRegistry) {
+    public PIDClient(
+            @Value("${pid.client.path:''}") String pathToFile,
+            @Value("${pid.client.root.path:/tmp/timetable/}") String rootPath,
+            MeterRegistry meterRegistry) {
         this.pathToFile = pathToFile;
+        this.rootPath = rootPath;
         this.meterRegistry = meterRegistry;
         log.info("Init PIDClient address is: {}", pathToFile);
         this.restClient = RestClient.builder()
                 .baseUrl(pathToFile)
                 .build();
 
-        folder = Paths.get("/tmp", "/timetable").toFile();
+        folder = Paths.get(rootPath).toFile();
         if (folder.exists() && folder.isDirectory()) {
             log.info("Folder {} exists", folder.getAbsolutePath());
         } else {
@@ -267,7 +271,7 @@ public class PIDClient {
     }
 
     /**
-     * Extracts all non-directory entries from a ZIP byte array into {@link #ROOT_PATH_FILE}.
+     * Extracts all non-directory entries from a ZIP byte array into the configured root path.
      * <p>
      * Each entry is written using its bare filename (directory components are stripped),
      * so nested ZIP paths are flattened into the single target directory.

--- a/server/src/main/java/org/hejnaluk/metrotimetable/config/PidClientProperties.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/config/PidClientProperties.java
@@ -1,0 +1,33 @@
+package org.hejnaluk.metrotimetable.config;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Set;
+
+@ConfigurationProperties(prefix = "pid.client")
+@Validated
+@Getter
+@Setter
+public class PidClientProperties {
+
+    private String path = "";
+
+    @NotBlank(message = "pid.client.root.path must not be blank")
+    private String rootPath = "/tmp/timetable/";
+
+    private int daysOffset = 7;
+
+    private Set<String> routeIds = Set.of();
+
+    @Getter
+    @Setter
+    public static class Station {
+        private int maxLimit = 15;
+    }
+
+    private Station station = new Station();
+}

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
@@ -7,13 +7,12 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import lombok.Builder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hejnaluk.metrotimetable.config.PidClientProperties;
 import org.hejnaluk.metrotimetable.dto.LineInfo;
 import org.hejnaluk.metrotimetable.dto.TrainDeparture;
 import org.hejnaluk.metrotimetable.dto.TripDetail;
 import org.hejnaluk.metrotimetable.dto.TripStop;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -34,14 +33,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class ParseTimetableService {
 
     private final MeterRegistry meterRegistry;
-
-    @Value("${pid.client.root.path:/tmp/timetable/}")
-    private String rootPath;
 
     /**
      * Get path to the file containing routes information
@@ -82,11 +77,16 @@ public class ParseTimetableService {
     /**
      * Expected set of routes to be parsed
      */
-    @Value("${pid.client.routes.ids:}")
     public final Set<String> routeIds;
-
-    @Value("${pid.client.station.max-limit:15}")
     private int maxLimit;
+    private String rootPath;
+
+    public ParseTimetableService(MeterRegistry meterRegistry, PidClientProperties properties) {
+        this.meterRegistry = meterRegistry;
+        this.routeIds = properties.getRouteIds();
+        this.maxLimit = properties.getStation().getMaxLimit();
+        this.rootPath = properties.getRootPath();
+    }
 
     /**
      * route_id,direction_id,stop_id,stop_sequence

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/ParseTimetableService.java
@@ -33,14 +33,15 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.hejnaluk.metrotimetable.client.PIDClient.ROOT_PATH_FILE;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ParseTimetableService {
 
     private final MeterRegistry meterRegistry;
+
+    @Value("${pid.client.root.path:/tmp/timetable/}")
+    private String rootPath;
 
     /**
      * Get path to the file containing routes information
@@ -337,7 +338,7 @@ public class ParseTimetableService {
      * @return path to the directory containing the GTFS text files
      */
     protected Path getRootPath() {
-        return Path.of(ROOT_PATH_FILE);
+        return Path.of(rootPath);
     }
 
     /**

--- a/server/src/main/java/org/hejnaluk/metrotimetable/service/TimetableRefreshService.java
+++ b/server/src/main/java/org/hejnaluk/metrotimetable/service/TimetableRefreshService.java
@@ -24,12 +24,18 @@ public class TimetableRefreshService {
     private final ParseTimetableService parseTimetableService;
     private final MeterRegistry meterRegistry;
 
+    private static final String TRIGGER_STARTUP = "startup";
+    private static final String TRIGGER_SCHEDULED = "scheduled";
+    private static final String TRIGGER_MANUAL = "manual";
+    private static final String OUTCOME_SUCCESS = "success";
+    private static final String OUTCOME_FAILURE = "failure";
+
     private final Map<String, Counter> refreshCounters = new HashMap<>();
 
     @PostConstruct
     void registerMetrics() {
-        for (String trigger : List.of("startup", "scheduled", "manual")) {
-            for (String outcome : List.of("success", "failure")) {
+        for (String trigger : List.of(TRIGGER_STARTUP, TRIGGER_SCHEDULED, TRIGGER_MANUAL)) {
+            for (String outcome : List.of(OUTCOME_SUCCESS, OUTCOME_FAILURE)) {
                 refreshCounters.put(trigger + "." + outcome, Counter.builder("timetable.refresh.total")
                         .description("Number of timetable refresh attempts by trigger and outcome")
                         .tag("trigger", trigger)
@@ -49,9 +55,9 @@ public class TimetableRefreshService {
         try {
             pidClient.getData();
             parseTimetableService.parseTimetableFiles();
-            refreshCounter("startup", "success").increment();
+            refreshCounter(TRIGGER_STARTUP, OUTCOME_SUCCESS).increment();
         } catch (Exception e) {
-            refreshCounter("startup", "failure").increment();
+            refreshCounter(TRIGGER_STARTUP, OUTCOME_FAILURE).increment();
             throw e;
         }
     }
@@ -72,9 +78,9 @@ public class TimetableRefreshService {
             } else {
                 log.info("No new GTFS data — skipping parse");
             }
-            refreshCounter("scheduled", "success").increment();
+            refreshCounter(TRIGGER_SCHEDULED, OUTCOME_SUCCESS).increment();
         } catch (Exception e) {
-            refreshCounter("scheduled", "failure").increment();
+            refreshCounter(TRIGGER_SCHEDULED, OUTCOME_FAILURE).increment();
             throw e;
         }
     }
@@ -87,9 +93,9 @@ public class TimetableRefreshService {
         try {
             pidClient.getData();
             parseTimetableService.parseTimetableFiles();
-            refreshCounter("manual", "success").increment();
+            refreshCounter(TRIGGER_MANUAL, OUTCOME_SUCCESS).increment();
         } catch (Exception e) {
-            refreshCounter("manual", "failure").increment();
+            refreshCounter(TRIGGER_MANUAL, OUTCOME_FAILURE).increment();
             throw e;
         }
     }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -6,6 +6,7 @@ cors.allowed-methods=GET,POST
 
 pid.client.path=https://data.pid.cz/PID_GTFS.zip
 pid.client.days.offset=7
+pid.client.root.path=/tmp/timetable/
 
 #pid.client.routes.ids=L991
 pid.client.routes.ids=L991,L992,L993

--- a/server/src/test/java/org/hejnaluk/metrotimetable/client/PIDClientTest.java
+++ b/server/src/test/java/org/hejnaluk/metrotimetable/client/PIDClientTest.java
@@ -17,6 +17,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.hejnaluk.metrotimetable.config.PidClientProperties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -32,7 +33,10 @@ class PIDClientTest {
     void setUp() throws IOException {
         server = new MockWebServer();
         server.start();
-        client = new PIDClient("http://localhost:" + server.getPort(), "/tmp/timetable/", new SimpleMeterRegistry());
+        PidClientProperties props = new PidClientProperties();
+        props.setPath("http://localhost:" + server.getPort());
+        props.setDaysOffset(0);
+        client = new PIDClient(props, new SimpleMeterRegistry());
         Files.deleteIfExists(SYNC_FILE);
         Files.deleteIfExists(EXTRACTED_FILE);
     }

--- a/server/src/test/java/org/hejnaluk/metrotimetable/client/PIDClientTest.java
+++ b/server/src/test/java/org/hejnaluk/metrotimetable/client/PIDClientTest.java
@@ -32,7 +32,7 @@ class PIDClientTest {
     void setUp() throws IOException {
         server = new MockWebServer();
         server.start();
-        client = new PIDClient("http://localhost:" + server.getPort(), new SimpleMeterRegistry());
+        client = new PIDClient("http://localhost:" + server.getPort(), "/tmp/timetable/", new SimpleMeterRegistry());
         Files.deleteIfExists(SYNC_FILE);
         Files.deleteIfExists(EXTRACTED_FILE);
     }

--- a/server/src/test/java/org/hejnaluk/metrotimetable/service/ParseTimetableServiceTest.java
+++ b/server/src/test/java/org/hejnaluk/metrotimetable/service/ParseTimetableServiceTest.java
@@ -1,6 +1,7 @@
 package org.hejnaluk.metrotimetable.service;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.hejnaluk.metrotimetable.config.PidClientProperties;
 import org.hejnaluk.metrotimetable.dto.LineInfo;
 import org.hejnaluk.metrotimetable.dto.TrainDeparture;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +47,9 @@ class ParseTimetableServiceTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        service = new ParseTimetableService(new SimpleMeterRegistry(), Set.of()) {
+        PidClientProperties props = new PidClientProperties();
+        props.setRouteIds(Set.of());
+        service = new ParseTimetableService(new SimpleMeterRegistry(), props) {
             @Override
             protected LocalTime getNow() {
                 return FIXED_NOW;


### PR DESCRIPTION
## Summary by Sourcery

Make timetable refresh metrics and PID client file paths more configurable and maintainable.

Enhancements:
- Replace hardcoded trigger and outcome strings in timetable refresh metrics with named constants.
- Make PID client root folder configurable via application properties and inject it into timetable parsing instead of using a hardcoded /tmp/timetable path.
- Update documentation comments to reflect the new configurable root path setting.

Documentation:
- Document the new pid.client.root.path configuration property in application properties.